### PR TITLE
fix: Error message fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ replay_pid*
 /mvnw
 /mvnw.cmd
 /target/
+.settings
+.classpath
+.factorypath
+.project

--- a/src/main/java/com/andrascsanyi/beanvalidationextensions/LongAsStringMustBeGreaterOrEqualToOne.java
+++ b/src/main/java/com/andrascsanyi/beanvalidationextensions/LongAsStringMustBeGreaterOrEqualToOne.java
@@ -1,33 +1,43 @@
 package com.andrascsanyi.beanvalidationextensions;
 
-import jakarta.validation.Constraint;
-import jakarta.validation.Payload;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 /**
  * Validates if the provided input {@link String} is equal or greater than 0 when it is parsed as Long.
  *
- * <p>This validation annotation is used to check values coming via GraphQL where the ID is {@link
- * String}
+ * <p>
+ * This validation annotation is might be used to check values coming via GraphQL where the ID is {@link String}.
  *
- * <p>The validation judges the null, empty or blank string values to be valid. The validation
- * judges the negative value to be invalid.
+ * <p>
+ * The validation judges the null, empty or blank string values to be valid. The validation judges the negative value to
+ * be invalid.
+ *
+ * @author Andras Csanyi
  */
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = LongAsStringMustBeGreaterOrEqualToOneValidator.class)
 @Documented
 public @interface LongAsStringMustBeGreaterOrEqualToOne {
-    String message() default "{com.andrascsanyi.encyclopediagalactica.common.validation" +
-        ".LongAsStringMustBeGreaterOrEqualToOne" +
-        ".message=The provided Long value as String must be equal to zero}";
-    
+
+    /**
+     * The error message when the constraint is violated.
+     */
+    String message() default "{com.andrascsanyi.beanvalidationextensions.LongAsStringMustBeGreaterOrEqualToOne}";
+
+    /**
+     * The group.
+     */
     Class<?>[] groups() default {};
-    
+
+    /**
+     * The payload.
+     */
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/andrascsanyi/beanvalidationextensions/LongAsStringMustBeZero.java
+++ b/src/main/java/com/andrascsanyi/beanvalidationextensions/LongAsStringMustBeZero.java
@@ -10,24 +10,24 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Validates if the provided input {@link String} is equal to 0 when it is parsed as Long.
+ * This constraint describes the case when the provided input {@link String} must be equal to 0 when it is parsed as
+ * {@link Long}.
  *
- * <p>This validation annotation is used to check values coming via GraphQL where the ID is {@link
- * String}.
+ * <p>
+ * The validation judges the negative value, the null, empty or blank string values to be valid.
  *
- * <p>The validation judges the negative value, the null, empty or blank string values to be valid.
+ * <p>
+ * <b>Use case:</b> This validation annotation is used to check values coming via GraphQL where the ID is
+ * {@link String}.
  */
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = LongAsStringMustBeZeroValidator.class)
 @Documented
 public @interface LongAsStringMustBeZero {
-    String message() default
-        "{com.andrascsanyi.encyclopediagalactica.common.validation" +
-            ".LongAsStringMustBeZero" +
-            ".message=The provided Long provided as string must be zero!}";
-    
+    String message() default "{com.andrascsanyi.encyclopediagalactica.common.validation.LongAsStringMustBeZero}";
+
     Class<?>[] groups() default {};
-    
+
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/andrascsanyi/beanvalidationextensions/LongValueMustBe.java
+++ b/src/main/java/com/andrascsanyi/beanvalidationextensions/LongValueMustBe.java
@@ -9,18 +9,20 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * This constrait describes the case when the provided {@link Long} value must be the provided {@link Long} value.
+ */
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = LongValueMustBeValidator.class)
 @Documented
 public @interface LongValueMustBe {
     long mustBe() default 0L;
-    String message() default "{com.andrascsanyi.encyclopediagalactica.common.validation" +
-        ".LongValueMustBe" +
-        ".message=The provided Long value must be equal to the defined one.}";
-    
+
+    String message() default "{com.andrascsanyi.encyclopediagalactica.common.validation.LongValueMustBe}";
+
     Class<?>[] groups() default {};
-    
+
     Class<? extends Payload>[] payload() default {};
-    
+
 }

--- a/src/main/java/com/andrascsanyi/beanvalidationextensions/LongValueMustBeGreaterOrEqualTo.java
+++ b/src/main/java/com/andrascsanyi/beanvalidationextensions/LongValueMustBeGreaterOrEqualTo.java
@@ -10,7 +10,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- *
+ * This constraint describes the case when the provided {@link Long} value must be greater or equal to the provided
+ * parameters.
  */
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
@@ -18,12 +19,11 @@ import java.lang.annotation.Target;
 @Documented
 public @interface LongValueMustBeGreaterOrEqualTo {
     long mustBeGreaterOrEqualTo() default Long.MIN_VALUE;
-    String message() default "{com.andrascsanyi.encyclopediagalactica.common.validation" +
-        ".LongValueMustBeGreaterOrEqualT" +
-        ".message=The provided value must be greater than or equal to the defined one}";
-    
+
+    String message() default "{com.andrascsanyi.encyclopediagalactica.common.validation.LongValueMustBeGreaterOrEqualT}";
+
     Class<?>[] groups() default {};
-    
+
     Class<? extends Payload>[] payload() default {};
-    
+
 }

--- a/src/main/java/com/andrascsanyi/beanvalidationextensions/TrimmedNotBlank.java
+++ b/src/main/java/com/andrascsanyi/beanvalidationextensions/TrimmedNotBlank.java
@@ -10,7 +10,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Validates if the provided {@link String} value is empty after it is trimmed.
+ * This constraint describes the case that the provided {@link String} value cannot be empty after it is trimmed.
  * <p>
  * The validator judges null to be invalid value.
  */
@@ -19,12 +19,10 @@ import java.lang.annotation.Target;
 @Constraint(validatedBy = TrimmedNotBlankValidator.class)
 @Documented
 public @interface TrimmedNotBlank {
-    
-    String message() default "{com.andrascsanyi.encyclopediagalactica.common.validation" +
-        ".TrimmedNotBlank" +
-        ".message=When the provided string is trimmed it must not be blank.}";
-    
+
+    String message() default "{com.andrascsanyi.encyclopediagalactica.common.validation.TrimmedNotBlank}";
+
     Class<?>[] groups() default {};
-    
+
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/andrascsanyi/beanvalidationextensions/TrimmedNotEmpty.java
+++ b/src/main/java/com/andrascsanyi/beanvalidationextensions/TrimmedNotEmpty.java
@@ -10,7 +10,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Validates if the provided {@link String} value is empty after it is trimmed.
+ * This constraint describes that the provided {@link String} value cannot be empty after it is trimmed.
  * <p>
  * The validator judges null to be invalid value.
  */
@@ -19,12 +19,10 @@ import java.lang.annotation.Target;
 @Constraint(validatedBy = TrimmedNotEmptyValidator.class)
 @Documented
 public @interface TrimmedNotEmpty {
-    
-    String message() default "{com.andrascsanyi.encyclopediagalactica.common.validation" +
-        ".TrimmedNotEmpty" +
-        ".message=When the provided string is trimmed it must not be empty}";
-    
+
+    String message() default "{com.andrascsanyi.encyclopediagalactica.common.validation.TrimmedNotEmpty}";
+
     Class<?>[] groups() default {};
-    
+
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/andrascsanyi/beanvalidationextensions/TrimmedSize.java
+++ b/src/main/java/com/andrascsanyi/beanvalidationextensions/TrimmedSize.java
@@ -10,22 +10,22 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Add documentation here
+ * This constraint describes that the provided {@link String} length must be between the provided minimum (inclusive) and maximum (exclusive)
+ * length after it is trimmed.
+ *
  */
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = TrimmedSizeValidator.class)
 @Documented
 public @interface TrimmedSize {
-    String message() default "{com.andrascsanyi.encyclopediagalactica.common.validation" +
-        ".TrimmedSize" +
-        ".message=When the provided string is trimmed it must be longer than and shorter than defined.}";
-    
+    String message() default "{com.andrascsanyi.encyclopediagalactica.common.validation.TrimmedSize}";
+
     Class<?>[] groups() default {};
-    
+
     Class<? extends Payload>[] payload() default {};
-    
+
     int min() default 0;
-    
+
     int max() default Integer.MAX_VALUE;
 }


### PR DESCRIPTION
By default the constraint descriptor interfaces had a lengthy error messages. This is now replaced to only the namespace.ConstraintAnnotationName pattern as it is in the `jakarta.validation.constraint` package.